### PR TITLE
Use the canonical tmpdir for the default share_file

### DIFF
--- a/lib/Cache/FastMmap.pm
+++ b/lib/Cache/FastMmap.pm
@@ -303,6 +303,9 @@ XSLoader::load('Cache::FastMmap', $VERSION);
 our %LiveCaches;
 
 use constant FC_ISDIRTY => 1;
+
+use File::Spec;
+
 # }}}
 
 =item I<new(%Opts)>
@@ -510,9 +513,8 @@ sub new {
   # Work out cache file and whether to init
   my $share_file = $Args{share_file};
   if (!$share_file) {
-    my $tmp_dir = $ENV{TMPDIR} || "/tmp";
-    my $win_tmp_dir = $ENV{TEMP} || "c:\\";
-    $share_file = ($^O eq "MSWin32" ? "$win_tmp_dir\\sharefile" : "$tmp_dir/sharefile");
+    my $tmp_dir = File::Spec->tmpdir;
+    $share_file = File::Spec->catfile($tmp_dir, "sharefile");
     $share_file .= "-" . $$ . "-" . time . "-" . int(rand(100000));
   }
   !ref($share_file) || die "share_file argument was a reference";


### PR DESCRIPTION
Rather than relaying on the environment or some hardcoded defaults, using File::Spec->tmpdir will _always_ give you a working temp dir; this is important for systems that either don't have a standard tempdir (VMS) or simply don't have a tempdir (android, blackberry 10).

..truth be told though, this patch was written just for Android. But on the flip side, share_file will now actually use the correct tempdir on Windows.
