### PR TITLE
Valgrind and code quality fixes

### DIFF
--- a/FastMmap.xs
+++ b/FastMmap.xs
@@ -300,8 +300,6 @@ NO_OUTPUT void
 fc_reset_page_details(obj)
     SV * obj;
   INIT:
-    MU32 nreads = 0, nreadhits = 0;
-
     FC_ENTRY
 
   CODE:
@@ -500,7 +498,7 @@ fc_set(obj, key, val)
     SV * key;
     SV * val;
   INIT:
-    int key_len, val_len, found;
+    int key_len, val_len;
     void * key_ptr, * val_ptr;
     MU32 hash_page, hash_slot, flags = 0;
     STRLEN pl_key_len, pl_val_len;

--- a/mmap_cache.c
+++ b/mmap_cache.c
@@ -616,7 +616,7 @@ int mmc_calc_expunge(
     MU32 * slot_end = slot_ptr + num_slots;
 
     /* Store pointers to used slots */
-    MU32 ** copy_base_det = (MU32 **)malloc(sizeof(MU32 *) * used_slots);
+    MU32 ** copy_base_det = (MU32 **)calloc(used_slots, sizeof(MU32 *));
     MU32 ** copy_base_det_end = copy_base_det + used_slots;
     MU32 ** copy_base_det_out = copy_base_det;
     MU32 ** copy_base_det_in = copy_base_det + used_slots;
@@ -728,11 +728,11 @@ int mmc_do_expunge(
 
   /* Build new slots data and KV data */
   MU32 slot_data_size = new_num_slots * 4;
-  MU32 * new_slot_data = (MU32 *)malloc(slot_data_size);
+  MU32 * new_slot_data = (MU32 *)calloc(1, slot_data_size);
 
   MU32 page_data_size = cache->c_page_size - new_num_slots * 4 - P_HEADERSIZE;
 
-  void * new_kv_data = malloc(page_data_size);
+  void * new_kv_data = calloc(1, page_data_size);
   MU32 new_offset = 0;
 
   /* Start all new slots empty */
@@ -838,11 +838,9 @@ void mmc_reset_page_details(mmap_cache * cache) {
  *
 */
 mmap_cache_it * mmc_iterate_new(mmap_cache * cache) {
-  mmap_cache_it * it = (mmap_cache_it *)malloc(sizeof(mmap_cache_it));
+  mmap_cache_it * it = (mmap_cache_it *)calloc(1, sizeof(mmap_cache_it));
   it->cache = cache;
   it->p_cur = -1;
-  it->slot_ptr = 0;
-  it->slot_ptr_end = 0;
 
   return it;
 }

--- a/mmap_cache.c
+++ b/mmap_cache.c
@@ -109,7 +109,7 @@ int mmc_get_param(mmap_cache * cache, char * param) {
 */
 int mmc_init(mmap_cache * cache) {
   int i, do_init;
-  MU32 c_num_pages, c_page_size, c_size, start_slots;
+  MU32 c_num_pages, c_page_size, c_size;
 
   /* Need a share file */
   if (!cache->share_file) {
@@ -124,8 +124,7 @@ int mmc_init(mmap_cache * cache) {
   c_page_size = cache->c_page_size;
   ASSERT(c_page_size >= 1024 && c_page_size <= 16*1024*1024);
 
-  start_slots = cache->start_slots;
-  ASSERT(start_slots >= 10 && start_slots <= 500);
+  ASSERT(cache->start_slots >= 10 && cache->start_slots <= 500);
 
   cache->c_size = c_size = c_num_pages * c_page_size;
 
@@ -629,7 +628,7 @@ int mmc_calc_expunge(
     for (; slot_ptr != slot_end; slot_ptr++) {
       MU32 data_offset = *slot_ptr;
       MU32 * base_det = S_Ptr(cache->p_base, data_offset);
-      MU32 expire_time, flags, kvlen;
+      MU32 expire_time, kvlen;
 
       /* Ignore if if free slot */
       if (data_offset <= 1) {
@@ -644,7 +643,6 @@ int mmc_calc_expunge(
 
       /* Definitely out if expired, and not dirty */
       expire_time = S_ExpireTime(base_det);
-      flags = S_Flags(base_det);
       if (expire_time && now >= expire_time) {
         *copy_base_det_out++ = base_det;
         continue;

--- a/mmap_cache.c
+++ b/mmap_cache.c
@@ -40,28 +40,20 @@ MU32    def_start_slots = 89;
  * 
 */
 mmap_cache * mmc_new() {
-  mmap_cache * cache = (mmap_cache *)malloc(sizeof(mmap_cache));
+  mmap_cache * cache = (mmap_cache *)calloc(1, sizeof(mmap_cache));
 
-  cache->mm_var = 0;
   cache->p_cur = -1;
 
   cache->c_num_pages = def_c_num_pages;
   cache->c_page_size = def_c_page_size;
-  cache->c_size = 0;
 
   cache->start_slots = def_start_slots;
   cache->expire_time = def_expire_time;
 
-  cache->fh = 0;
   cache->share_file = _mmc_get_def_share_filename(cache);
   cache->permissions = 0640;
   cache->init_file = def_init_file;
   cache->test_file = def_test_file;
-
-  cache->catch_deadlocks = 0;
-  cache->enable_stats = 0;
-
-  cache->last_error = 0;
 
   return cache;
 }

--- a/unix.c
+++ b/unix.c
@@ -71,10 +71,12 @@ int mmc_open_cache_file(mmap_cache* cache, int * do_init) {
     for (i = 0; i < cache->c_num_pages; i++) {
       int written = write(res, tmp, cache->c_page_size);
       if (written < 0) {
+        free(tmp);
         _mmc_set_error(cache, errno, "Write to share file %s failed", cache->share_file);
         return -1;
       }
       if (written < cache->c_page_size) {
+        free(tmp);
         _mmc_set_error(cache, errno, "Write to share file %s failed; short write (%d of %d bytes written)", cache->share_file, written, cache->c_page_size);
         return -1;
       }

--- a/unix.c
+++ b/unix.c
@@ -62,13 +62,12 @@ int mmc_open_cache_file(mmap_cache* cache, int * do_init) {
     }
 
     /* Fill file with 0's */
-    tmp = malloc(cache->c_page_size);
+    tmp = calloc(1, cache->c_page_size);
     if (!tmp) {
-      _mmc_set_error(cache, errno, "Malloc of tmp space failed");
+      _mmc_set_error(cache, errno, "Calloc of tmp space failed");
       return -1;
     }
 
-    memset(tmp, 0, cache->c_page_size);
     for (i = 0; i < cache->c_num_pages; i++) {
       int written = write(res, tmp, cache->c_page_size);
       if (written < 0) {

--- a/win32.c
+++ b/win32.c
@@ -66,13 +66,12 @@ int mmc_open_cache_file(mmap_cache* cache, int* do_init) {
         }
         
         /* Fill file with 0's */
-        tmp = malloc(cache->c_page_size);
+        tmp = calloc(1, cache->c_page_size);
         if (!tmp) {
-            _mmc_set_error(cache, GetLastError(), "Malloc of tmp space failed");
+            _mmc_set_error(cache, GetLastError(), "Calloc of tmp space failed");
             return -1;
         }
         
-        memset(tmp, 0, cache->c_page_size);
         for (i = 0; i < cache->c_num_pages; i++) {
             DWORD tmpOut;
             WriteFile(fh, tmp, cache->c_page_size, &tmpOut, NULL);


### PR DESCRIPTION
While trying to sort out a memory corruption issue, I noticed the following from Valgrind:

```
   Conditional jump or move depends on uninitialised value(s)
     mmc_unlock (/home/greg/MaxMind/cache-fastmmap/blib/arch/auto/Cache/FastMmap/FastMmap.so) [?:?]
     XS_Cache__FastMmap_fc_unlock (/home/greg/MaxMind/cache-fastmmap/blib/arch/auto/Cache/FastMmap/FastMmap.so) [?:?]
     Perl_pp_entersub (/home/greg/.plenv/versions/5.26.3/bin/perl5.26.3) [?:?]
     Perl_runops_standard (/home/greg/.plenv/versions/5.26.3/bin/perl5.26.3) [?:?]
     Perl_call_sv (/home/greg/.plenv/versions/5.26.3/bin/perl5.26.3) [?:?]
     S_curse (/home/greg/.plenv/versions/5.26.3/bin/perl5.26.3) [?:?]
     Perl_sv_clear (/home/greg/.plenv/versions/5.26.3/bin/perl5.26.3) [?:?]
     Perl_sv_free2 (/home/greg/.plenv/versions/5.26.3/bin/perl5.26.3) [?:?]
     Perl_sv_setsv_flags (/home/greg/.plenv/versions/5.26.3/bin/perl5.26.3) [?:?]
     Perl_pp_sassign (/home/greg/.plenv/versions/5.26.3/bin/perl5.26.3) [?:?]
     Perl_runops_standard (/home/greg/.plenv/versions/5.26.3/bin/perl5.26.3) [?:?]
     perl_run (/home/greg/.plenv/versions/5.26.3/bin/perl5.26.3) [?:?]
     main (/home/greg/.plenv/versions/5.26.3/bin/perl5.26.3) [?:?]
     Uninitialised value was created by a heap allocation
       malloc (/usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so) [?:?]
       mmc_new (/home/greg/MaxMind/cache-fastmmap/blib/arch/auto/Cache/FastMmap/FastMmap.so) [?:?]
       XS_Cache__FastMmap_fc_new (/home/greg/MaxMind/cache-fastmmap/blib/arch/auto/Cache/FastMmap/FastMmap.so) [?:?]
       Perl_pp_entersub (/home/greg/.plenv/versions/5.26.3/bin/perl5.26.3) [?:?]
       Perl_runops_standard (/home/greg/.plenv/versions/5.26.3/bin/perl5.26.3) [?:?]
       perl_run (/home/greg/.plenv/versions/5.26.3/bin/perl5.26.3) [?:?]
       main (/home/greg/.plenv/versions/5.26.3/bin/perl5.26.3) [?:?]
```

I also noticed some memory leaks and unused variables that I fixed.

There are quite a few places where unsigned integers are compared to 0 or negative numbers.

` cache->p_cur` is unsigned and gets assigned `-1`, relying on the underflow behavior. I am not sure if this is intentional, but some of the later comparisons look suspicious if it is.