### PR TITLE
Fix race condition when creating file

### DIFF
--- a/unix.c
+++ b/unix.c
@@ -22,6 +22,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <time.h>
+#include <unistd.h>
 #include <errno.h>
 #include <stdarg.h>
 #include "mmap_cache.h"
@@ -33,66 +34,60 @@ char* _mmc_get_def_share_filename(mmap_cache * cache)
 }
 
 int mmc_open_cache_file(mmap_cache* cache, int * do_init) {
-  int res, i, fh;
-  void * tmp;
+  int res, fh;
   struct stat statbuf;
-
-  /* Check if file exists */
-  res = stat(cache->share_file, &statbuf);
-
-  /* Remove if different size or remove requested */
-  if (!res &&
-      (cache->init_file || (statbuf.st_size != cache->c_size))) {
-    res = remove(cache->share_file);
-    if (res == -1 && errno != ENOENT) {
-      _mmc_set_error(cache, errno, "Unlink of existing share file %s failed", cache->share_file);
-      return -1;
-    }
-  }
 
   /* Create file if it doesn't exist */
   *do_init = 0;
-  res = stat(cache->share_file, &statbuf);
+  mode_t permissions = (mode_t)cache->permissions;
+  fh = open(cache->share_file, O_RDWR | O_CREAT, permissions);
+  if (fh == -1) {
+    _mmc_set_error(cache, errno, "Opening of share file %s failed", cache->share_file);
+    return -1;
+  }
+
+  struct flock fl = { .l_type = F_WRLCK, .l_whence = SEEK_SET};
+
+  // Try to obtain an exclusive lock
+  res = fcntl(fh, F_SETLKW, &fl);
   if (res == -1) {
-    mode_t permissions = (mode_t)cache->permissions;
-    res = open(cache->share_file, O_WRONLY | O_CREAT | O_EXCL | O_TRUNC | O_APPEND, permissions);
+    _mmc_set_error(cache, errno, "Locking of share file %s failed", cache->share_file);
+    close(fh);
+    return -1;
+  }
+
+  res = fstat(fh, &statbuf);
+  if (res == -1) {
+    _mmc_set_error(cache, errno, "Getting size of share file %s failed", cache->share_file);
+    close(fh);
+    return -1;
+  }
+
+  /* Remove if different size or remove requested */
+  if (cache->init_file || (statbuf.st_size != cache->c_size)) {
+    res = ftruncate(fh, 0);
+    if (res == -1 && errno != ENOENT) {
+      _mmc_set_error(cache, errno, "Truncating of share file %s failed", cache->share_file);
+      close(fh);
+      return -1;
+    }
+
+    // Fill the file with 0s
+    res = ftruncate(fh, cache->c_size);
     if (res == -1) {
-      _mmc_set_error(cache, errno, "Create of share file %s failed", cache->share_file);
+      _mmc_set_error(cache, errno, "Truncating of share file %s failed", cache->share_file);
+      close(fh);
       return -1;
     }
-
-    /* Fill file with 0's */
-    tmp = calloc(1, cache->c_page_size);
-    if (!tmp) {
-      _mmc_set_error(cache, errno, "Calloc of tmp space failed");
-      return -1;
-    }
-
-    for (i = 0; i < cache->c_num_pages; i++) {
-      int written = write(res, tmp, cache->c_page_size);
-      if (written < 0) {
-        free(tmp);
-        _mmc_set_error(cache, errno, "Write to share file %s failed", cache->share_file);
-        return -1;
-      }
-      if (written < cache->c_page_size) {
-        free(tmp);
-        _mmc_set_error(cache, 0, "Write to share file %s failed; short write (%d of %d bytes written)", cache->share_file, written, cache->c_page_size);
-        return -1;
-      }
-    }
-    free(tmp);
 
     /* Later on initialise page structures */
     *do_init = 1;
-
-    close(res);
   }
-
-  /* Open for reading/writing */
-  fh = open(cache->share_file, O_RDWR);
-  if (fh == -1) {
-    _mmc_set_error(cache, errno, "Open of share file %s failed", cache->share_file);
+  fl.l_type   = F_UNLCK;
+  res = fcntl(fh, F_SETLK, &fl);
+  if (res == -1) {
+    _mmc_set_error(cache, errno, "Unlocking of share file %s failed", cache->share_file);
+    close(fh);
     return -1;
   }
 


### PR DESCRIPTION
This fixes a race condition when creating a new file with multiple
processes that could result in a SIGBUS, e.g.:

```
    Program terminated with signal SIGBUS, Bus error.
    0  __memset_avx2_erms () at ../sysdeps/x86_64/multiarch/memset-vec-unaligned-erms.S:141
    1  0x00007f9b476c1bf9 in _mmc_init_page (cache=0x562e26507730, p_cur=1807) at mmap_cache.c:1077
    2  0x00007f9b476c1f2d in mmc_init (cache=0x562e26507730) at mmap_cache.c:180
    3  0x00007f9b476c0633 in XS_Cache__FastMmap_fc_init (cv=<optimized out>) at FastMmap.c:252
    4  0x0000562e1d78e718 in Perl_pp_entersub () at pp_hot.c:5232
    5  0x0000562e1d784e63 in Perl_runops_standard () at run.c:41
    6  0x0000562e1d705924 in Perl_call_sv (sv=sv@entry=0x562e1f862788, flags=flags@entry=13) at perl.c:3021
    7  0x0000562e1d70800e in Perl_call_list (oldscope=oldscope@entry=2, paramList=0x562e1f8628d8) at perl.c:5061
    8  0x0000562e1d6e8fb1 in S_process_special_blocks (floor=floor@entry=45, fullname=<optimized out>, fullname@entry=0x562e1f86d930 "BEGIN",
       cv=cv@entry=0x562e1f862788, gv=<optimized out>) at op.c:10350
    9  0x0000562e1d6ff856 in Perl_newATTRSUB_x (floor=floor@entry=45, o=<optimized out>, proto=<optimized out>, proto@entry=0x0, attrs=<optimized out>,
       attrs@entry=0x0, block=0x562e1f86d840, block@entry=0x562e1f86d8c0, o_is_gv=o_is_gv@entry=false) at op.c:10275
    10 0x0000562e1d7026d6 in Perl_utilize (aver=<optimized out>, floor=45, version=<optimized out>, idop=0x562e1f86c748, arg=<optimized out>) at op.c:7484
    11 0x0000562e1d735e1c in Perl_yyparse (gramtype=gramtype@entry=258) at perly.y:329
    12 0x0000562e1d70b83a in S_parse_body (xsinit=0x562e1d6e7230 <xs_init>, env=0x0) at perl.c:2509
    13 perl_parse (my_perl=<optimized out>, xsinit=0x562e1d6e7230 <xs_init>, argc=<optimized out>, argv=<optimized out>, env=0x0) at perl.c:1803
    14 0x0000562e1d6e7066 in main (argc=<optimized out>, argv=<optimized out>, env=<optimized out>) at perlmain.c:121
```

This happens as one process could create the file and be filling it with
0s while another process would memory map and try to initialize the
file.

This also addresses races during the file size check.

This does not address the race during initialization of the pages.
Although those should not result in segfaults, we would ideally lock the
file until it was fully initialized. I avoided doing this primarily
because I didn't want to deal with the win32 code.